### PR TITLE
don't update bahmni, openmrs & mysql

### DIFF
--- a/packer/scripts/base.sh
+++ b/packer/scripts/base.sh
@@ -18,7 +18,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-mysql" > /etc/yum.repos.d/mysql56.rep
     sudo wget https://bintray.com/bahmni/rpm/rpm -O /etc/yum.repos.d/bintray-bahmni-rpm.repo
     wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
     rpm -Uvh epel-release-latest-6.noarch.rpm
-    yum -y update
+    yum -y -x 'bahmni*' -x 'openmrs' -x 'mysql-community*' update
 }
 
 install_oracle_jre(){


### PR DESCRIPTION
If we use that script to update Bahmni it would update here to the newest version of bahmni, openmrs & mysql
Bahmni would be the newest available version, not the one we have specified in $BAHMNI_VERSION
OpenMRS & MySQL are gonna be deleted and reinstalled anyway by "yum remove -y mysql-libs"
