### PR TITLE
Print where bahmni can be accessed

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,4 +11,6 @@ Vagrant.configure(2) do |config|
   config.vm.provider "virtualbox" do |v|
      v.customize ["modifyvm", :id, "--memory", 3092, "--cpus", 2, "--name", "Bahmni-RPM"]
   end
+  config.vm.provision "shell", privileged: false,
+    inline: "echo 'Bahmni can now be accessed at https://192.168.33.10/home'"
 end


### PR DESCRIPTION
so people new to bahmni/vagrant easily see where to go next after having
ran `vagrant up` successfully

I know there is a table with app/link/user/pw here https://bahmni.atlassian.net/wiki/spaces/BAH/pages/14712841/Bahmni+Virtual+Box
and it says it at the top here https://bahmni.atlassian.net/wiki/spaces/BAH/pages/32604585/Setting+up+Bahmni+Dev+Environment but I had people working on it and it took them quite some time to figure that out :(

we print the entire table or simply link to the table at https://bahmni.atlassian.net/wiki/spaces/BAH/pages/14712841/Bahmni+Virtual+Box

just a thought.

this is how it would look (with holding command key down you can directly open up bahmni)

<img width="682" alt="screen shot 2018-05-01 at 11 12 57" src="https://user-images.githubusercontent.com/4661144/39468002-293b5d6c-4d31-11e8-9804-2908baca81ae.png">



